### PR TITLE
Added macro to reduce calc array length

### DIFF
--- a/separatorSup/separator_stability.db
+++ b/separatorSup/separator_stability.db
@@ -71,7 +71,7 @@ record(acalcout, "$(P)_STABILITYCHECK")
 {
     field(DESC, "Finds number of samples outside limits")
     field(OOPT, "Every Time")
-    field(NELM, "$(NELM)")
+    field(NELM, "$(FILTEREDLEN)")
 
     # 0 if sample is within threshold, 1 if sample is outside threshold
     # A is upper limit, B is lower limit, C + D is current threshold


### PR DESCRIPTION
### Description of work
Define a second length for the working array to calculate the stability of the separator

### To test
https://github.com/ISISComputingGroup/IBEX/issues/4160

### Acceptance criteria

- [x] The separator does not always report 1 out of range sample due to the difference in sizes of the filtered and unfiltered data