### PR TITLE
Ticket 5513: Updated to the standard epics way of running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,14 +24,6 @@ $(foreach dir, $(filter %Top, $(DIRS)), \
 # iocBoot depends on all *App dirs
 iocBoot_DEPEND_DIRS += $(filter %App,$(DIRS))
 
-TEST_RUNNER = $(TOP)/separatorSup/O.$(EPICS_HOST_ARCH)/runner
-
 # Add any additional dependency rules here:
 
 include $(TOP)/configure/RULES_TOP
-
-.PHONY: test
-test:
-ifneq ($(wildcard $(TEST_RUNNER)*),)
-	$(TEST_RUNNER) --gtest_output=xml:$(TOP)/test-reports/TEST-Separator.xml
-endif

--- a/separatorSup/Makefile
+++ b/separatorSup/Makefile
@@ -24,17 +24,17 @@ SEPRTR_LIBS += asubFunctions
 
 #=======================================
 # googleTest Runner
-# Does not currently build on build servers
 
 ifeq ($(findstring 10.0,$(VCVERSION)),)
 
-TESTPROD_HOST += runner
-USR_CPPFLAGS += -I$(GTEST)/googletest/include
-runner_SRCS += run_all_tests.cc
+GTESTPROD_HOST += runner
 
 runner_SRCS += separator_tests.cc separator_filtering.cpp
-runner_LIBS += gtest $(SEPRTR_LIBS)
+runner_LIBS += $(SEPRTR_LIBS)
+
+GTESTS += runner 
 
 endif
 #=======================================
 include $(TOP)/configure/RULES
+include $(GTEST)/cfg/compat.RULES_BUILD

--- a/separatorSup/run_all_tests.cc
+++ b/separatorSup/run_all_tests.cc
@@ -1,6 +1,0 @@
-#include "gtest/gtest.h"
-
-int main(int argc, char **argv) {
-    ::testing::InitGoogleTest( &argc, argv );
-    return RUN_ALL_TESTS();
-    }


### PR DESCRIPTION
See https://github.com/ISISComputingGroup/IBEX/issues/5513

To test:

* Run `make runtests` in this submodule and confirm tests run