### PR TITLE
Ticket4711 remove separator stability units

### DIFF
--- a/separatorSup/separator_stability.db
+++ b/separatorSup/separator_stability.db
@@ -151,8 +151,8 @@ record(calc, "$(P)STABILITY:_CALC")
 record(bi, "$(P)STABILITY") {
     field(DESC, "Separator stability status")
 
-    field(ZNAM, "unstable")
-    field(ONAM, "stable")
+    field(ZNAM, "Unstable")
+    field(ONAM, "Stable")
     field(INP,  "$(P)STABILITY:_CALC CP MSS")
 
     field(ZSV, "MAJOR")

--- a/separatorSup/separator_stability.db
+++ b/separatorSup/separator_stability.db
@@ -150,7 +150,7 @@ record(calc, "$(P)STABILITY:_CALC")
 
 record(bi, "$(P)STABILITY") {
     field(DESC, "Separator stability status")
-    field(EGU, "")
+
     field(ZNAM, "unstable")
     field(ONAM, "stable")
     field(INP,  "$(P)STABILITY:_CALC CP MSS")
@@ -206,7 +206,7 @@ record(scalcout, "$(P)_DISABLEALARMS")
 record(sseq, "$(P)ALARMSTATUS")
 {
     field(DOL1, "$(P)_DISABLEALARMS.OSV CP")
-    field(LNK1, "$(P)STABILITY:_CALC.LSV PP")
+    field(LNK1, "$(P)STABILITY.ZSV PP")
     field(DOL2, "$(P)_DISABLEALARMS.OSV CP")
     field(LNK2, "$(P)UNSTABLETIME.HSV PP")
 

--- a/separatorSup/separator_stability.db
+++ b/separatorSup/separator_stability.db
@@ -139,7 +139,6 @@ record(calc, "$(P)UNSTABLETIME")
 record(calc, "$(P)STABILITY:_CALC")
 {
     field(DESC, "1 if stable, 0 otherwise")
-    field(EGU, "")
     field(SCAN, "Passive")
     field(CALC, "A < B")
 
@@ -151,8 +150,9 @@ record(calc, "$(P)STABILITY:_CALC")
 
 record(bi, "$(P)STABILITY") {
     field(DESC, "Separator stability status")
-    field(ZNAM, "unstable")    
-    field(ONAM, "stable")     
+    field(EGU, "")
+    field(ZNAM, "unstable")
+    field(ONAM, "stable")
     field(INP,  "$(P)STABILITY:_CALC CP MSS")
 
     field(ZSV, "MAJOR")

--- a/separatorSup/separator_stability.db
+++ b/separatorSup/separator_stability.db
@@ -139,7 +139,7 @@ record(calc, "$(P)UNSTABLETIME")
 record(calc, "$(P)STABILITY")
 {
     field(DESC, "1 if stable, 0 otherwise")
-    field(EGU, "s")
+    field(EGU, "")
     field(SCAN, "Passive")
     field(CALC, "A < B")
 

--- a/separatorSup/separator_stability.db
+++ b/separatorSup/separator_stability.db
@@ -136,7 +136,7 @@ record(calc, "$(P)UNSTABLETIME")
     info(INTEREST, "HIGH")
 }
 
-record(calc, "$(P)STABILITY")
+record(calc, "$(P)STABILITY:_calc")
 {
     field(DESC, "1 if stable, 0 otherwise")
     field(EGU, "")
@@ -145,18 +145,22 @@ record(calc, "$(P)STABILITY")
 
     field(INPA, "$(P)UNSTABLETIME CP MSS")
     field(INPB, "$(P)THRESHOLD")
+    
+    field(ASG, "READONLY")
+}
 
-    field(LOW, "0.5")
-    field(LSV, "MAJOR")
+record(bi, "$(P)STABILITY") {
+    field(DESC, "Separator stability status")
+    field(ZNAM, "unstable")    
+    field(ONAM, "stable")     
+    field(INP,  "$(P)STABILITY:_calc CP MSS")
 
-    field(HIGH, "9999")
-    field(HSV, "NO_ALARM")
+    field(ZSV, "MAJOR")
+    field(OSV, "NO_ALARM")
 
     info(alarm, "SEPRTR")
     info(archive, "VAL")
     info(INTEREST, "HIGH")
-    
-    field(ASG, "READONLY")
 }
 
 record(aSub, "$(P)STABILITY:PARSE")
@@ -202,7 +206,7 @@ record(scalcout, "$(P)_DISABLEALARMS")
 record(sseq, "$(P)ALARMSTATUS")
 {
     field(DOL1, "$(P)_DISABLEALARMS.OSV CP")
-    field(LNK1, "$(P)STABILITY.LSV PP")
+    field(LNK1, "$(P)STABILITY:_calc.LSV PP")
     field(DOL2, "$(P)_DISABLEALARMS.OSV CP")
     field(LNK2, "$(P)UNSTABLETIME.HSV PP")
 

--- a/separatorSup/separator_stability.db
+++ b/separatorSup/separator_stability.db
@@ -136,7 +136,7 @@ record(calc, "$(P)UNSTABLETIME")
     info(INTEREST, "HIGH")
 }
 
-record(calc, "$(P)STABILITY:_calc")
+record(calc, "$(P)STABILITY:_CALC")
 {
     field(DESC, "1 if stable, 0 otherwise")
     field(EGU, "")
@@ -153,7 +153,7 @@ record(bi, "$(P)STABILITY") {
     field(DESC, "Separator stability status")
     field(ZNAM, "unstable")    
     field(ONAM, "stable")     
-    field(INP,  "$(P)STABILITY:_calc CP MSS")
+    field(INP,  "$(P)STABILITY:_CALC CP MSS")
 
     field(ZSV, "MAJOR")
     field(OSV, "NO_ALARM")
@@ -206,7 +206,7 @@ record(scalcout, "$(P)_DISABLEALARMS")
 record(sseq, "$(P)ALARMSTATUS")
 {
     field(DOL1, "$(P)_DISABLEALARMS.OSV CP")
-    field(LNK1, "$(P)STABILITY:_calc.LSV PP")
+    field(LNK1, "$(P)STABILITY:_CALC.LSV PP")
     field(DOL2, "$(P)_DISABLEALARMS.OSV CP")
     field(LNK2, "$(P)UNSTABLETIME.HSV PP")
 


### PR DESCRIPTION
### Description:

Removed STABILITY unit field as it was confusing, replaced old one with "`$(P)STABILITY:_CALC`", while "`$(P)STABILITY`" will have the stability value as a text label ("stable"/"unstable") instead of the old (0/1 - 0 unstable, 1 stable)

### For ticket:
https://github.com/ISISComputingGroup/IBEX/issues/4711

### Testing:
Tested with EPICS-IOC_Test_Framework/blob/master/tests/separator.py 
Ticket has link to other pull request with adjusted tests