### PR TITLE
Update Makefile

### DIFF
--- a/separatorSup/Makefile
+++ b/separatorSup/Makefile
@@ -37,4 +37,4 @@ GTESTS += runner
 endif
 #=======================================
 include $(TOP)/configure/RULES
-include $(GTEST)/cfg/compat.RULES_BUILD
+include $(GTEST)/configure/RULES


### PR DESCRIPTION
I'm getting these errors when trying to build the separator:
```
Makefile:40: C:/Instrument/Apps/EPICS/support/googletest/master/cfg/compat.RULES_BUILD: No such file or directory
make[1]: *** No rule to make target 'C:/Instrument/Apps/EPICS/support/googletest/master/cfg/compat.RULES_BUILD'.  Stop.
make: *** [C:/Instrument/Apps/EPICS/base/master/configure/RULES_DIRS:87: separatorSup.clean] Error 2
```
I think the rules file for the build is incorrect, it builds okay with this change